### PR TITLE
Update AlertManager.php

### DIFF
--- a/src/AlertManager.php
+++ b/src/AlertManager.php
@@ -24,7 +24,7 @@ class AlertManager implements LogEventAwareInterface
         $alertLevel = isset($payload['alert_level']) ? $payload['alert_level'] : LogLevel::INFO;
 
         // Additional values
-        $payload['wp_home']            = WP_HOME;
+        $payload['wp_home']            = get_home_url(get_main_site_id());
         $payload['domain']             = get_home_url();
         $payload['client_ip']          = $this->getClientIP();
         $payload['client_remote_addr'] = $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
I'm not sure what info `domain` should contain, but one suggestion is to differentiate between current blog and main site, i.e. on a network wordpress with the  `wp_home` = main site url while `domain` = current blog.

The current code:
```php
$payload['wp_home']            = WP_HOME;
```

generates an error #1